### PR TITLE
[deps] Add make

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -46,6 +46,7 @@ apt-get install -y \
     git \
     inetutils-ping \
     sudo \
+    make \
     ;
 
 # Hook up the runner user with passwordless sudo


### PR DESCRIPTION
I believe `make` is included by default in GitHub's hosted runners.